### PR TITLE
Improve test teardown

### DIFF
--- a/make.m
+++ b/make.m
@@ -91,11 +91,9 @@ function success = run_tests(varargin)
   original_path = path;
   addpath(test_path);
   addpath(lib_path);
+  cleanup = onCleanup(@() path(original_path)); % restore path after finish
 
   success = runner(varargin{:});
-
-  % restore path
-  path(original_path);
 end
 
 function success = build(varargin)

--- a/tests/runner.m
+++ b/tests/runner.m
@@ -1,89 +1,88 @@
 function success = runner(varargin)
-  % Run tests for the library
-  %
-  % ## Arguments
-  %   - [...]: variable list of tests.
-  %
-  % If no argument is provided, all the files `test*.m` under the directory
-  % of this file will run.
-  %
-  % Notice that the files will be considered relative to this file.
+    % Run tests for the library
+    %
+    % ## Arguments
+    %   - [...]: variable list of tests.
+    %
+    % If no argument is provided, all the files `test*.m` under the directory
+    % of this file will run.
+    %
+    % Notice that the files will be considered relative to this file.
 
-  [test_path, ~, ~] = fileparts(mfilename('fullpath'));
+    [testPath, ~, ~] = fileparts(mfilename('fullpath'));
 
-  % save current path
-  original_path = path;
-  addpath(test_path);
-  addpath(fullfile(test_path, 'support'));
-  
+    % save current path
+    origPath = path;
+    addpath(testPath);
+    addpath(fullfile(testPath, 'support'));
+    cleanupObj = onCleanup(@() path(origPath)); % restore path after finish
 
-  failures = {};
-  nfailures = 0;
-  nsuccess  = 0;
+    failures = {};
+    nfailures = 0;
+    nsuccess  = 0;
 
-  % Get the test files
-  if nargin > 0
-    tests = varargin;
-  else
-    try
-      tests = cellstr(ls(fullfile(test_path, 'test*.m')));
-    catch
-      tests = {};
+    % Get the test files
+    if (nargin > 0)
+        tests = varargin;
+    else
+        try
+            tests = cellstr(ls(fullfile(testPath, 'test*.m')));
+        catch
+            tests = {};
+        end
     end
-  end
 
-  fprintf('Running tests:\n\n');
-  tic;
-  for n = 1:length(tests)
-    % Failed tests should throw an exception
-    try
-      [~, funcname, ~] = fileparts(tests{n});
-      func = str2func(funcname);
-      func();
-      fprintf('.');
-      nsuccess = nsuccess + 1;
-    catch e
-      fprintf('F');
-      % Check if it is octave (`try...catch` not 100% > needs workaround)
-      if exist('OCTAVE_VERSION', 'builtin'); e = lasterror; end
-      % Save the failure, in order to posterior display
-      nfailures = nfailures + 1;
-      failures{nfailures} = e;
+    fprintf('Running tests:\n\n');
+    tic;
+    for n = 1:length(tests)
+        % Failed tests should throw an exception
+        try
+            [~, funcname, ~] = fileparts(tests{n});
+            func = str2func(funcname);
+            func();
+            fprintf('.');
+            nsuccess = nsuccess + 1;
+        catch e
+            fprintf('F');
+            % Check if it is octave (`try...catch` not 100% > needs workaround)
+            if (exist('OCTAVE_VERSION', 'builtin'))
+                e = lasterror;
+            end
+            % Save the failure, in order to posterior display
+            nfailures = nfailures + 1;
+            failures{nfailures} = e;
+        end
     end
-  end
 
-  fprintf('\n\n');
-  toc;
-  fprintf('\n\n');
+    fprintf('\n\n');
+    toc;
+    fprintf('\n\n');
 
-  % restore path
-  path(original_path);
-
-  if nfailures > 0
-    success = 0;
-    % Throw all failures as one
-    error('Tests: %d passed, %d failed.\n\n%s\n', nsuccess, nfailures, ...
-      strjoin(cellfun(@reportgen, failures, 'UniformOutput', false), '\n'));
-    % An error will ensure the exit code different from 0 in case of any not-well-succeeded test.
-    % This is useful for continuous-integration services.
-  else
-    success = 1;
-    fprintf('All tests passed.\n');
-  end
+    if nfailures > 0
+        success = 0;
+        % Throw all failures as one
+        error('Tests: %d passed, %d failed.\n\n%s\n', nsuccess, nfailures, ...
+            strjoin(cellfun(@reportgen, failures, 'UniformOutput', false), '\n'));
+        % An error will ensure the exit code different from 0 in case of any not-well-succeeded test.
+        % This is useful for continuous-integration services.
+    else
+        success = 1;
+        fprintf('All tests passed.\n');
+    end
 end
 
 function output = reportgen(err)
-  stack = find_test(err.stack);
-  output = sprintf('%s (line %d):\n\t%s\n', stack.name, stack.line, err.message);
+    stack = find_test(err.stack);
+    output = sprintf('%s (line %d):\n\t%s\n', stack.name, stack.line, err.message);
 end
 
 function output = find_test(stack)
-  n = 1;
-  l = length(stack);
+    n = 1;
+    l = length(stack);
 
-  while isempty(regexp(stack(n).name, '^test', 'once')) && n < l
-    n = n + 1;
-  end
+    while (isempty(regexp(stack(n).name, '^test', 'once')) && n < l)
+        n = n + 1;
+    end
 
-  output = stack(n);
+    output = stack(n);
 end

--- a/tests/test_zmq_bind.m
+++ b/tests/test_zmq_bind.m
@@ -1,10 +1,9 @@
 function test_zmq_bind
-    % let's just create and destroy a dummy socket
-    ctx = zmq_ctx_new();
-    socket = zmq_socket(ctx, 'ZMQ_PUB');
+    [ctx, socket] = setup;
+    cleanupObj = onCleanup(@() teardown(ctx, socket));
 
     %% binding
-    assert_throw('EPROTONOSUPPORT', @zmq_bind, socket, 'abc://localhost'); % invalid transport
+    assert_throw('EPROTONOSUPPORT', @zmq_bind, socket, 'abc://localhost'); % invalid transport - TODO sometimes it throws "zmq:bind:unknownOops" ("No such file or directory").
     assert_throw('EINVAL', @zmq_bind, socket, 'tcp://localhost');          % port must specified
     response = assert_does_not_throw(@zmq_bind, socket, 'tcp://127.0.0.1:30000');
     assert(response == 0, 'status code should be 0, %d given.', response);
@@ -13,7 +12,15 @@ function test_zmq_bind
     assert_throw(@zmq_unbind, socket, 'tcp://127.0.0.1:30103');
     response = assert_does_not_throw(@zmq_unbind, socket, 'tcp://127.0.0.1:30000');
     assert(response == 0, 'status code should be 0, %d given.', response);
+end
 
+function [ctx, socket] = setup
+    % let's just create and destroy a dummy socket
+    ctx = zmq_ctx_new();
+    socket = zmq_socket(ctx, 'ZMQ_PUB');
+end
+
+function teardown(ctx, socket)
     % close session
     zmq_close(socket);
     zmq_ctx_shutdown(ctx);

--- a/tests/test_zmq_connect.m
+++ b/tests/test_zmq_connect.m
@@ -1,7 +1,6 @@
 function test_zmq_connect
-    % let's just create and destroy a dummy socket
-    ctx = zmq_ctx_new();
-    socket = zmq_socket(ctx, 'ZMQ_SUB');
+    [ctx, socket] = setup;
+    cleanupObj = onCleanup(@() teardown(ctx, socket));
 
     %% connecting
     assert_throw('EPROTONOSUPPORT', @zmq_connect, socket, 'abc://localhost'); % invalid transport
@@ -13,7 +12,15 @@ function test_zmq_connect
     assert_throw(@zmq_disconnect, socket, 'tcp://127.0.0.1:30103');
     response = assert_does_not_throw(@zmq_disconnect, socket, 'tcp://127.0.0.1:30000');
     assert(response == 0, 'status code should be 0, %d given.', response);
+end
 
+function [ctx, socket] = setup
+    % let's just create and destroy a dummy socket
+    ctx = zmq_ctx_new();
+    socket = zmq_socket(ctx, 'ZMQ_SUB');
+end
+
+function teardown(ctx, socket)
     % close session
     zmq_close(socket);
     zmq_ctx_shutdown(ctx);

--- a/tests/test_zmq_ctx_get.m
+++ b/tests/test_zmq_ctx_get.m
@@ -1,28 +1,35 @@
 function test_zmq_ctx_get
-  % let's just create a dummy context
-  ctx = zmq_ctx_new();
+    ctx = setup;
+    cleanupObj = onCleanup(@() teardown(ctx));
 
-  % Once the context is fresh and unused, all the options should remain with the
-  % default values.
+    % Once the context is fresh and unused, all the options should remain with the
+    % default values.
 
-  % ZMQ_IO_THREADS Default Value: 1
-  nthreads = zmq_ctx_get(ctx, 'ZMQ_IO_THREADS');
-  assert(nthreads == 1, 'ZMQ_IO_THREADS should be 1, %d given.', nthreads);
+    % ZMQ_IO_THREADS Default Value: 1
+    nthreads = zmq_ctx_get(ctx, 'ZMQ_IO_THREADS');
+    assert(nthreads == 1, 'ZMQ_IO_THREADS should be 1, %d given.', nthreads);
 
-  % ZMQ_IPV6 Default Value: 0
-  ipv6 = zmq_ctx_get(ctx, 'ZMQ_IPV6');
-  assert(ipv6 == 0, 'ZMQ_IPV6 should be 0, %d given.', ipv6);
+    % ZMQ_IPV6 Default Value: 0
+    ipv6 = zmq_ctx_get(ctx, 'ZMQ_IPV6');
+    assert(ipv6 == 0, 'ZMQ_IPV6 should be 0, %d given.', ipv6);
 
-  % ZMQ_MAX_SOCKETS Default Value: 1024
-  maxs = zmq_ctx_get(ctx, 'ZMQ_MAX_SOCKETS');
-  assert(maxs == 1024 || maxs == 1023, ...
+    % ZMQ_MAX_SOCKETS Default Value: 1024
+    maxs = zmq_ctx_get(ctx, 'ZMQ_MAX_SOCKETS');
+    assert(maxs == 1024 || maxs == 1023, ...
     'ZMQ_MAX_SOCKETS should be 1024, %d given (I suspect receiving 1023 is OK).', maxs);
 
-  % NOTICE:
-  % According to documentation (http://api.zeromq.org/4-0:zmq-ctx-set)
-  % it should be 1024, but `zmq.h` defines it as 1023...
+    % NOTICE:
+    % According to documentation (http://api.zeromq.org/4-0:zmq-ctx-set)
+    % it should be 1024, but `zmq.h` defines it as 1023...
+end
 
-  % close session
-  zmq_ctx_shutdown(ctx);
-  zmq_ctx_term(ctx);
+function ctx = setup
+    % let's just create a dummy context
+    ctx = zmq_ctx_new();
+end
+
+function teardown(ctx)
+    % close session
+    zmq_ctx_shutdown(ctx);
+    zmq_ctx_term(ctx);
 end

--- a/tests/test_zmq_getsockopt.m
+++ b/tests/test_zmq_getsockopt.m
@@ -1,7 +1,6 @@
 function test_zmq_getsockopt
-    % let's just create a dummy socket
-    ctx = zmq_ctx_new();
-    socket = zmq_socket(ctx, 'ZMQ_REP');
+    [ctx, socket] = setup;
+    cleanupObj = onCleanup(@() teardown(ctx, socket));
 
     % Table with the default values for options
     defaultOptions = { ...
@@ -59,7 +58,15 @@ function test_zmq_getsockopt
 
         assert(condition, '%s should be %s, %s given.', option, value, response);
     end
+end
 
+function [ctx, socket] = setup
+    % let's just create and destroy a dummy socket
+    ctx = zmq_ctx_new();
+    socket = zmq_socket(ctx, 'ZMQ_REP');
+end
+
+function teardown(ctx, socket)
     % close session
     zmq_close(socket);
     zmq_ctx_shutdown(ctx);

--- a/tests/test_zmq_req_rep.m
+++ b/tests/test_zmq_req_rep.m
@@ -1,12 +1,6 @@
 function test_zmq_req_rep
-    %% open session
-    ctx = zmq_ctx_new();
-
-    client = zmq_socket(ctx, 'ZMQ_REQ');
-    zmq_connect(client, 'tcp://127.0.0.1:30000');
-
-    server = zmq_socket(ctx, 'ZMQ_REP');
-    zmq_bind(server, 'tcp://127.0.0.1:30000');
+    [ctx, server, client] = setup;
+    cleanupObj = onCleanup(@() teardown(ctx, server, client));
 
     %% client test - request send
     msgSent = uint8('request');
@@ -46,7 +40,20 @@ function test_zmq_req_rep
     %% client test - cannot send 2 messages in a row (unless multipart)
     assert_does_not_throw(@zmq_send, client, msgSent);
     assert_throw(@zmq_send, client, msgSent);
+end
 
+function [ctx, server, client] = setup
+    %% open session
+    ctx = zmq_ctx_new();
+
+    client = zmq_socket(ctx, 'ZMQ_REQ');
+    zmq_connect(client, 'tcp://127.0.0.1:30000');
+
+    server = zmq_socket(ctx, 'ZMQ_REP');
+    zmq_bind(server, 'tcp://127.0.0.1:30000');
+end
+
+function teardown(ctx, server, client)
     %% close session
     zmq_unbind(server, 'tcp://127.0.0.1:30000');
     zmq_close(server);

--- a/tests/test_zmq_req_rep_multipart.m
+++ b/tests/test_zmq_req_rep_multipart.m
@@ -1,12 +1,6 @@
 function test_zmq_req_rep_multipart
-    %% open session
-    ctx = zmq_ctx_new();
-
-    client = zmq_socket(ctx, 'ZMQ_REQ');
-    zmq_connect(client, 'tcp://127.0.0.1:30000');
-
-    server = zmq_socket(ctx, 'ZMQ_REP');
-    zmq_bind(server, 'tcp://127.0.0.1:30000');
+    [ctx, server, client] = setup;
+    cleanupObj = onCleanup(@() teardown(ctx, server, client));
 
     %% client test - request send
     msgSent = uint8('request');
@@ -21,7 +15,20 @@ function test_zmq_req_rep_multipart
     msg2 = zmq_recv(server);
     rc = zmq_getsockopt(server, 'ZMQ_RCVMORE');
     assert(rc == 0, 'ZMQ_RCVMORE option should be 0, after receive all parts in a multipart message');
+end
 
+function [ctx, server, client] = setup
+    %% open session
+    ctx = zmq_ctx_new();
+
+    client = zmq_socket(ctx, 'ZMQ_REQ');
+    zmq_connect(client, 'tcp://127.0.0.1:30000');
+
+    server = zmq_socket(ctx, 'ZMQ_REP');
+    zmq_bind(server, 'tcp://127.0.0.1:30000');
+end
+
+function teardown(ctx, server, client)
     %% close session
     zmq_unbind(server, 'tcp://127.0.0.1:30000');
     zmq_close(server);

--- a/tests/test_zmq_setsockopt.m
+++ b/tests/test_zmq_setsockopt.m
@@ -1,7 +1,6 @@
 function test_zmq_setsockopt
-    % let's just create a dummy socket
-    ctx = zmq_ctx_new();
-    socket = zmq_socket(ctx, 'ZMQ_REQ');
+    [ctx, socket] = setup;
+    cleanupObj = onCleanup(@() teardown(ctx, socket));
 
     % -- Options not tested here------------------------------------------------- %
     %% Read-Only properties
@@ -81,7 +80,15 @@ function test_zmq_setsockopt
 
         assert(condition, '%s should be %s, %s given.', option, value, response);
     end
+end
 
+function [ctx, socket] = setup
+    % let's just create and destroy a dummy socket
+    ctx = zmq_ctx_new();
+    socket = zmq_socket(ctx, 'ZMQ_REQ');
+end
+
+function teardown(ctx, socket)
     % close session
     zmq_close(socket);
     zmq_ctx_shutdown(ctx);

--- a/tests/test_zmq_socket.m
+++ b/tests/test_zmq_socket.m
@@ -1,11 +1,18 @@
 function test_zmq_socket
-    ctx = zmq_ctx_new();
+    ctx = setup;
+    cleanupObj = onCleanup(@() teardown(ctx));
 
     % let's just create and destroy a dummy socket
     socket = assert_does_not_throw(@zmq_socket, ctx, 'ZMQ_REP');
     response = assert_does_not_throw(@zmq_close, socket);
     assert(response == 0, 'status code should be 0, %d given.', response);
+end
 
+function ctx = setup
+    ctx = zmq_ctx_new();
+end
+
+function teardown(ctx)
     % close session
     zmq_ctx_shutdown(ctx);
     zmq_ctx_term(ctx);


### PR DESCRIPTION
Hi Ashton,

I have learned this little trick for ensure some code run after the function complete (or fails), I think it's good to avoid endpoint colisions when tests fail.

``` matlab
cleanupObj = onCleanup(cleanupFun)
```
