### PR TITLE
Complete error message namespace cleanup

### DIFF
--- a/lib/+zmq/+core/recv.m
+++ b/lib/+zmq/+core/recv.m
@@ -23,7 +23,7 @@
 % * ZMQ_DONTWAIT
 %       Specifies that the operation should be performed in non-blocking mode.
 %       If there are no messages available on the specified socket, the
-%       zmq.core.recv() function shall fail with zmq:recv:EAGAIN error code.
+%       zmq.core.recv() function shall fail with zmq:core:recv:EAGAIN error code.
 %
 %
 % NOTICE
@@ -34,7 +34,7 @@
 %      `unicode2native(str, 'UTF-8')` or
 %      `feature('DefaultCharacterSet', 'UTF-8')`.
 %  - If the pre-allocated buffer is shorter than the message received, the returned
-%    vector will be truncated and a `zmq:recv:bufferTooSmall` warning will be thrown.
+%    vector will be truncated and a `zmq:core:recv:bufferTooSmall` warning will be thrown.
 %
 % EXAMPLE
 %     feature('DefaultCharacterSet', 'UTF-8');
@@ -46,7 +46,7 @@
 %       % maximum size of message2: 255 bytes
 %       fprintf('Received message2: %s\n', char(message2));
 %     catch e
-%       if strcmp(e.identifier, 'zmq:recv:EAGAIN')
+%       if strcmp(e.identifier, 'zmq:core:recv:EAGAIN')
 %         fprintf('No message available.\n');
 %       else
 %         rethrow(e);

--- a/lib/+zmq/+core/send.m
+++ b/lib/+zmq/+core/send.m
@@ -11,7 +11,7 @@
 % Output:  number of bytes in the message if successful, otherwise -1.
 %
 % If the message cannot be queued on the socket, the zmq.core.send() function shall
-% fail with zmq:send:EAGAIN error code.
+% fail with zmq:core:send:EAGAIN error code.
 %
 % The following options are considered valid:
 %

--- a/src/core/setsockopt.c
+++ b/src/core/setsockopt.c
@@ -17,17 +17,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     int rc;
 
     if (nrhs != 3) {
-        mexErrMsgIdAndTxt("zmq:core:sockopts:invalidArgs",
+        mexErrMsgIdAndTxt("zmq:core:setsockopt:invalidArgs",
                 "Error: Tree arguments are required: socket, option, value");
         return;
     }
     if (mxIsChar(prhs[1]) != 1) {
-        mexErrMsgIdAndTxt("zmq:core:sockopts:invalidOptionName",
+        mexErrMsgIdAndTxt("zmq:core:setsockopt:invalidOptionName",
                 "Error: option_name is not a string.");
         return;
     }
     if (mxGetM(prhs[1]) != 1) {
-        mexErrMsgIdAndTxt("zmq:core:sockopts:optionNameNotRowVec",
+        mexErrMsgIdAndTxt("zmq:core:setsockopt:optionNameNotRowVec",
                 "Error: option_name is not a row vector.");
         return;
     }

--- a/src/util/socket.c
+++ b/src/util/socket.c
@@ -52,7 +52,7 @@ const zmq_socket_type_t* find_socket_type_by_name(char* type) {
     }
 
     if (descriptor == NULL) {
-        mexErrMsgIdAndTxt("zmq:socket:invalidTypeName",
+        mexErrMsgIdAndTxt("zmq:core:socket:invalidTypeName",
             "Error: socket type %s is invalid.", type);
     }
     return descriptor;
@@ -83,7 +83,7 @@ const zmq_socket_type_t* find_socket_type_by_id(int id) {
     }
 
     if (descriptor == NULL) {
-        mexErrMsgIdAndTxt("zmq:socket:invalidTypeId",
+        mexErrMsgIdAndTxt("zmq:core:socket:invalidTypeId",
             "Error: socket type %d is invalid.", id);
     }
     return descriptor;
@@ -137,23 +137,23 @@ void socket_error() {
 
     switch (err) {
         case EINVAL:
-            mexErrMsgIdAndTxt("zmq:socket:invalidOptsCore",
+            mexErrMsgIdAndTxt("zmq:core:socket:invalidOptsCore",
                     "Error: The core API reports that something has gone wrong."
                     "\n(original message: %s)", zmq_strerror(err));
         break;
         case ETERM:
-            mexErrMsgIdAndTxt("zmq:socket:contextTerm",
+            mexErrMsgIdAndTxt("zmq:core:socket:contextTerm",
                     "Error: The context associated with the socket was terminated."
                     "\n(original message: %s)", zmq_strerror(err));
         break;
         case EFAULT:
         case ENOTSOCK:
-            mexErrMsgIdAndTxt("zmq:socket:invalidSocket",
+            mexErrMsgIdAndTxt("zmq:core:socket:invalidSocket",
                     "Error: Invalid socket."
                     "\n(original message: %s)", zmq_strerror(err));
         break;
         case EINTR:
-            mexErrMsgIdAndTxt("zmq:socket:interrupted",
+            mexErrMsgIdAndTxt("zmq:core:socket:interrupted",
                     "Error: The operation was interrupted by a signal."
                     "\n(original message: %s)", zmq_strerror(err));
         break;

--- a/src/util/sockopt.c
+++ b/src/util/sockopt.c
@@ -146,7 +146,7 @@ const zmq_sockopt_desc_t* find_sockopt_by_name(char* option) {
     }
 
     if (descriptor == NULL) {
-        mexErrMsgIdAndTxt("zmq:sockopt:invalidOptionName",
+        mexErrMsgIdAndTxt("zmq:core:sockopt:invalidOptionName",
             "Error: socket_option %s is invalid.", option);
     }
     return descriptor;
@@ -177,7 +177,7 @@ const zmq_sockopt_type_t* find_sockopt_type_by_id(int typeId) {
         }
     }
     if (descriptor == NULL) {
-        mexErrMsgIdAndTxt("zmq:sockopt:invalidOptionTypeId",
+        mexErrMsgIdAndTxt("zmq:core:sockopt:invalidOptionTypeId",
             "Error: socket_option typeId %d is invalid.", typeId);
     }
     return descriptor;
@@ -208,7 +208,7 @@ const zmq_sockopt_mechanism_t* find_sockopt_mechanism_by_id(int mechanismId) {
         }
     }
     if (descriptor == NULL) {
-        mexErrMsgIdAndTxt("zmq:sockopt:invalidOptionMechanismId",
+        mexErrMsgIdAndTxt("zmq:core:sockopt:invalidOptionMechanismId",
             "Error: socket_option mechanism %d is invalid.", mechanismId);
     }
     return descriptor;
@@ -234,7 +234,7 @@ const zmq_sockopt_mechanism_t* find_sockopt_mechanism_by_name(char* name) {
         }
     }
     if (descriptor == NULL) {
-        mexErrMsgIdAndTxt("zmq:sockopt:invalidOptionMechanism",
+        mexErrMsgIdAndTxt("zmq:core:sockopt:invalidOptionMechanism",
             "Error: socket_option mechanism %s is invalid.", name);
     }
     return descriptor;

--- a/tests/test_socket_bind.m
+++ b/tests/test_socket_bind.m
@@ -5,7 +5,7 @@ function test_socket_bind
         'UniformOutput', false));
 
     %% binding
-    assert_throw('EPROTONOSUPPORT', @socket.bind, 'abc://localhost'); % invalid transport - TODO sometimes it throws "zmq:bind:unknownOops" ("No such file or directory").
+    assert_throw('EPROTONOSUPPORT', @socket.bind, 'abc://localhost'); % invalid transport - TODO sometimes it throws "zmq:core:bind:unknownOops" ("No such file or directory").
     assert_throw('EINVAL', @socket.bind, 'tcp://localhost');          % port must specified
     assert_does_not_throw(@socket.bind, 'tcp://127.0.0.1:30000');
 

--- a/tests/test_socket_send_recv.m
+++ b/tests/test_socket_send_recv.m
@@ -32,7 +32,7 @@ function test_socket_send_recv
     %% client test - response receive
     delta = 2; % buffer reduction
     origState = warning; % save for further restoring
-    warning('off', 'zmq:recv:bufferTooSmall');
+    warning('off', 'zmq:core:recv:bufferTooSmall');
     msgRecv = client.recv(msgSentSz-delta, 'dontwait');
     warning(origState);
     assert(strcmp(char(msgSent(1:end-delta)), char(msgRecv)), ...

--- a/tests/test_zmq_bind.m
+++ b/tests/test_zmq_bind.m
@@ -3,7 +3,7 @@ function test_zmq_bind
     cleanupObj = onCleanup(@() teardown(ctx, socket));
 
     %% binding
-    assert_throw('EPROTONOSUPPORT', @zmq.core.bind, socket, 'abc://localhost'); % invalid transport - TODO sometimes it throws "zmq:bind:unknownOops" ("No such file or directory").
+    assert_throw('EPROTONOSUPPORT', @zmq.core.bind, socket, 'abc://localhost'); % invalid transport - TODO sometimes it throws "zmq:core:bind:unknownOops" ("No such file or directory").
     assert_throw('EINVAL', @zmq.core.bind, socket, 'tcp://localhost');          % port must specified
     response = assert_does_not_throw(@zmq.core.bind, socket, 'tcp://127.0.0.1:30000');
     assert(response == 0, 'status code should be 0, %d given.', response);

--- a/tests/test_zmq_req_rep.m
+++ b/tests/test_zmq_req_rep.m
@@ -30,7 +30,7 @@ function test_zmq_req_rep
     %% client test - response receive
     delta = 2; % buffer reduction
     origState = warning; % save for further restoring
-    warning('off', 'zmq:recv:bufferTooSmall');
+    warning('off', 'zmq:core:recv:bufferTooSmall');
     msgRecv = zmq.core.recv(client, msgSentSz-delta, 'ZMQ_DONTWAIT');
     warning(origState);
     assert(strcmp(char(msgSent(1:end-delta)), char(msgRecv)), ...


### PR DESCRIPTION
Include `core` in the namespace for error messages.
