### PR TITLE
Fixes Windows MSVC++ make Problem and improves zmq_recv non-blocking

### DIFF
--- a/config_win.m
+++ b/config_win.m
@@ -8,4 +8,4 @@ ZMQ_COMPILED_LIB = 'libzmq-v120-mt-4_0_4.lib';
 ZMQ_LIB_PATH = 'C:\Program Files\ZeroMQ 4.0.4\lib\';
 
 % ZMQ headers path
-ZMQ_INCLUDE_PATH = 'C:\Program Files\ZeroMQ 4.0.4\include\';
+ZMQ_INCLUDE_PATH = 'C:\Program Files\ZeroMQ 4.0.4\include';

--- a/src/core/recv.c
+++ b/src/core/recv.c
@@ -53,8 +53,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     if (coreAPIReturn < 0) {
         /* Check if error is due to non-blocking with no message */
-        if (errno == EAGAIN)
-        {
+        if (errno == EAGAIN) {
             /* no error, so return zmq_recv return value */
             plhs[0] = mxCreateNumericMatrix(1, 1, mxINT32_CLASS, mxREAL);
             *((int*)mxGetData(plhs[0])) = coreAPIReturn;

--- a/src/core/recv.c
+++ b/src/core/recv.c
@@ -52,7 +52,15 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     coreAPIReturn = zmq_recv(socket, buffer, bufLen * sizeof(uint8_t), coreAPIOptionFlag);
 
     if (coreAPIReturn < 0) {
-        handle_error();
+        // Check if error is due to non-blocking with no message
+        if (errno == EAGAIN)
+        {
+            // no error, so return zmq_recv return value
+            plhs[0] = mxCreateNumericMatrix(1, 1, mxINT32_CLASS, mxREAL);
+            *((int*)mxGetData(plhs[0])) = coreAPIReturn;
+        }
+        else
+            handle_error();
     } else {
         /* Prepare the values that should be returned to MATLAB */
         configure_return(nlhs, plhs, coreAPIReturn, bufLen, buffer);

--- a/src/core/recv.c
+++ b/src/core/recv.c
@@ -52,10 +52,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     coreAPIReturn = zmq_recv(socket, buffer, bufLen * sizeof(uint8_t), coreAPIOptionFlag);
 
     if (coreAPIReturn < 0) {
-        // Check if error is due to non-blocking with no message
+        /* Check if error is due to non-blocking with no message */
         if (errno == EAGAIN)
         {
-            // no error, so return zmq_recv return value
+            /* no error, so return zmq_recv return value */
             plhs[0] = mxCreateNumericMatrix(1, 1, mxINT32_CLASS, mxREAL);
             *((int*)mxGetData(plhs[0])) = coreAPIReturn;
         }


### PR DESCRIPTION
When running make.m under Windows 7, Matlab R2015a, with Microsoft Visual C++ 2013 Professional,  cl.exe fails with the error below; removing the '\' at the end of the include
appears to fix the issue.  If possible suggest testing if problem occurs with other MSVC compilers.

================================================
Error using mex
cl : Command line warning D9021 : no action performed

cl : Command line warning D9024 : unrecognized source file type 'Files\MATLAB\R2015a\extern\include
-IC:\Program', object file assumed
cl : Command line warning D9027 : source file 'Files\MATLAB\R2015a\extern\include -IC:\Program'
ignored
cl : Command line warning D9024 : unrecognized source file type
'Files\MATLAB\R2015a\simulink\include D:\ryan\IHI\repos\matlab-zmq\src\core\version.c
/FoC:\Users\ryan\AppData\Local\Temp\mex_60789195930209_5164\version.obj ', object file assumed
cl : Command line warning D9027 : source file 'Files\MATLAB\R2015a\simulink\include
D:\ryan\IHI\repos\matlab-zmq\src\core\version.c
/FoC:\Users\ryan\AppData\Local\Temp\mex_60789195930209_5164\version.obj ' ignored


Error in make>compile (line 213)
    mex('-largeArrayDims', '-O', flags{:}, deps{:}, file, '-output', outputfile);

Error in make>@(file)compile(zmq_compile_flags,file,fullfile(lib_path,'+zmq/+core')) (line 166)
  build_function = @(file) compile(zmq_compile_flags, file, fullfile(lib_path,'+zmq/+core'));

Error in make>build (line 167)
  cellfun(build_function, COMPILE_LIST);

Error in make (line 40)
    success = build;
================================================
 

When using the ZMQ_DONTWAIT option during a zmq_recv, if there is no message present, the method returns with a negative value, but sets errno to EAGAIN; however, EAGAIN is not being caught and instead an error is thrown.  This change fixes that and returns the negative number when the call would block.