### PR TITLE
Update recv.c

### DIFF
--- a/src/core/recv.c
+++ b/src/core/recv.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <util/socket.h>
 #include <util/conversions.h>
 #include <util/errors.h>
@@ -7,47 +8,53 @@
 
 #define DEFAULT_BUFFER_LENGTH 255
 
-int configure_flag(const mxArray **, int);
+int configure_flag(const mxArray*);
 void configure_return(int, mxArray **, int, size_t, void *);
-size_t configure_buffer_length(const mxArray **, int *);
+size_t configure_buffer_length(const mxArray*);
+void free_at_exit(void);
+
+static void *buffer = NULL;
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
     void *socket = NULL;
-    void *buffer = NULL;
-    size_t bufLen = DEFAULT_BUFFER_LENGTH;
-    int optionStart = 1;  /* from which index options can be passed */
-    int coreAPIReturn, coreAPIOptionFlag = 0;
+    size_t bufLen = 0;
+    int coreAPIReturn = 0;
+    int coreAPIOptionFlag = 0;
 
+    /* Require at least one argument */
     if (nrhs < 1) {
         mexErrMsgIdAndTxt("zmq:core:recv:invalidArgs",
-                "Error: At least one argument is required: socket.");
+            "Error: At least one argument is required: socket.");
         return;
     }
 
-    if (nrhs >= 2) {
-        /* Check if the user has chosen a bufLen,
-         * if so get it and update the index where options should start */
-        bufLen = configure_buffer_length(prhs, &optionStart);
-        if (bufLen == 0)
-            return;
-
-        /* Get the options for receiving */
-        coreAPIOptionFlag = configure_flag(&(prhs[optionStart]), nrhs - optionStart);
-    }
-
+    /* Open the socket */
     socket = pointer_from_m(prhs[0]);
     if (socket == NULL) {
         mexErrMsgIdAndTxt("zmq:core:recv:invalidSocket", "Error: Invalid socket.");
         return;
     }
+    
+    /* Get bufLen and update the index where options should start */
+    if (nrhs >= 2) {
+      bufLen = configure_buffer_length(prhs[1]);
+    } else {
+      bufLen = DEFAULT_BUFFER_LENGTH;
+    }
 
-    /* Create buffer and call API */
-    buffer = (uint8_t*) mxCalloc(bufLen, sizeof(uint8_t));
+    /* Get the options for receiving */
+    if (nrhs >= 3) {
+        coreAPIOptionFlag = configure_flag(prhs[2]);
+    }
+
+    /* Reallocate buffer and call API */
+    buffer = (uint8_t*) realloc(buffer, bufLen * sizeof(uint8_t));
     if (buffer == NULL) {
-        mexErrMsgIdAndTxt("util:calloc", "Error: Unsuccessful memory allocation.");
+        mexErrMsgIdAndTxt("util:realloc", "Error: Unsuccessful memory allocation.");
         return;
     }
+    mexAtExit(free_at_exit);
 
     coreAPIReturn = zmq_recv(socket, buffer, bufLen * sizeof(uint8_t), coreAPIOptionFlag);
 
@@ -64,26 +71,21 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         /* Prepare the values that should be returned to MATLAB */
         configure_return(nlhs, plhs, coreAPIReturn, bufLen, buffer);
     }
-
-    mxFree(buffer);
 }
 
-/* Discover which options are passed by the user, and calculate the
- * corresponding flag */
-int configure_flag(const mxArray **params, int nParams)
+/* Discover which options are passed by the user, and calculate the corresponding flag */
+int configure_flag(const mxArray *param)
 {
-    int i, coreAPIOptionFlag = 0;
+    int coreAPIOptionFlag = 0;
     char *flagStr = NULL;
 
-    for (i = 0 ; i < nParams; i++) {
-        flagStr = (char *) str_from_m(params[i]);
-        if (flagStr != NULL) {
-            if(strcmp(flagStr, "ZMQ_DONTWAIT") == 0)
-                coreAPIOptionFlag |= ZMQ_DONTWAIT;
-            else
-                mexErrMsgIdAndTxt("zmq:core:recv:invalidFlag", "Error: Unknown flag.");
-            mxFree(flagStr);
-        }
+    flagStr = (char *) str_from_m(param);
+    if (flagStr != NULL) {
+        if(strcmp(flagStr, "ZMQ_DONTWAIT") == 0)
+            coreAPIOptionFlag |= ZMQ_DONTWAIT;
+        else
+            mexErrMsgIdAndTxt("zmq:core:recv:invalidFlag", "Error: Unknown flag.");
+        mxFree(flagStr);
     }
 
     return coreAPIOptionFlag;
@@ -91,14 +93,14 @@ int configure_flag(const mxArray **params, int nParams)
 
 /* Check if the message was truncated, advising user and avoiding memory waste
  * while prepare it to return to MATLAB. Also handle the second optional return */
-void configure_return(int nlhs, mxArray **plhs, int msgLen, size_t bufLen, void *buffer) {
+void configure_return(int nlhs, mxArray **plhs, int msgLen, size_t bufLen, void *buf) {
     if (msgLen > bufLen) {
         mexWarnMsgIdAndTxt("zmq:core:recv:bufferTooSmall",
             "Message is %d bytes long, but buffer is %d. Truncated.",
             msgLen, bufLen);
-        plhs[0] = uint8_array_to_m((void*) buffer, bufLen);
+        plhs[0] = uint8_array_to_m((void*) buf, bufLen);
     } else {
-        plhs[0] = uint8_array_to_m((void*) buffer, msgLen);
+        plhs[0] = uint8_array_to_m((void*) buf, msgLen);
     }
 
     if (nlhs > 1) {
@@ -106,24 +108,32 @@ void configure_return(int nlhs, mxArray **plhs, int msgLen, size_t bufLen, void 
     }
 }
 
-/* Check if the param in the index is an number
- * if so, convert it from MATLAB and increments the index */
-size_t configure_buffer_length(const mxArray **param, int *paramIndex)
+/* Check if the param is a number. If so, convert it from MATLAB */
+size_t configure_buffer_length(const mxArray *param)
 {
-    size_t length = DEFAULT_BUFFER_LENGTH;
-    size_t *input;
+    size_t length = 0;
+    size_t *input = NULL;
 
-    if (mxIsNumeric(param[*paramIndex])) {
-        input = (size_t*) size_t_from_m(param[*paramIndex]);
-        *paramIndex += 1;
-        if (input != NULL) {
-            length = *input;
-            mxFree(input);
-        } else {
-            mexErrMsgIdAndTxt("zmq:core:recv:unknowOops", "Unable to convert parameter.");
-            return 0;
-        }
+    if (!mxIsNumeric(param)) {
+        mexErrMsgIdAndTxt("zmq:core:recv:unknowOops", "Buffer length parameter must be numeric.");
+        return 0;
     }
+    
+    input = (size_t*) size_t_from_m(param);
+    if (input == NULL) {
+        mexErrMsgIdAndTxt("zmq:core:recv:unknowOops", "Unable to convert parameter.");
+        return 0;
+    }
+    
+    length = *input;
+    mxFree(input);
 
     return length;
+}
+
+/* Frees the buffer at program exit */
+void free_at_exit(void)
+{
+  free(buffer);
+  return;
 }


### PR DESCRIPTION
Fixed a performance problem when receiving large messages of unknown size. Also, changed the recv() inputs to more closely match the zmq API (without breaking any unit tests). The zmq API requires a buffer allocation for the largest anticipated message (if the buffer is too small, then the message will be truncated). The previous implementation of matlab-zmq recv() triggered allocation/deallocation of the largest anticipated buffer during each call from MATLAB, even if the actual message received was trivially small. With the submitted change, the buffer is declared as a static variable and the memory is (re)allocated using realloc. Finally, mexAtExit is used to register a function to free memory on program termination.