### PR TITLE
Update setsockopt.c to accept strings containing null

### DIFF
--- a/src/core/setsockopt.c
+++ b/src/core/setsockopt.c
@@ -53,7 +53,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     optLen = typeDesc->maxLen;
     /* Correct len for compound types */
     if (typeDesc->id == SOPT_STRING || typeDesc->id == SOPT_KEY) {
-        optLen = strlen((char*) optValue)*sizeof(char);
+        optLen = mxGetNumberOfElements(prhs[2]);
     }
 
     rc = zmq_setsockopt(socket, optDesc->id, optValue, optLen);


### PR DESCRIPTION
In the master version of matlab-zmq, a ZMQ_SUBSCRIBE message filter is treated as a SOPT_STRING, which is truncated at the first null terminating character on Line 56. This is not the correct behavior, because message filters are allowed to contain binary data including null characters. Since this is a MEX interface, we can use msGetNumberOfElements to get the correct optLen.
